### PR TITLE
Re allow use of .env file using load.environment.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,12 @@
         "drupal/drupal": "~7",
         "drush/drush": "~8",
         "webflo/drupal-finder": "^1.0.0",
-        "webmozart/path-util": "^2.3"
+        "webmozart/path-util": "^2.3",
+        "vlucas/phpdotenv": "^2.4"
     },
     "autoload": {
-        "psr-4": {"RoyGoldman\\DrupalWrapper\\": "src/"}
+        "psr-4": {"RoyGoldman\\DrupalWrapper\\": "src/"},
+        "files": ["load.environment.php"]
     },
     "extra": {
         "class": "RoyGoldman\\DrupalWrapper\\Plugin"

--- a/load.environment.php
+++ b/load.environment.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * This file is included very early. See autoload.files in composer.json and
+ * https://getcomposer.org/doc/04-schema.md#files
+ */
+
+use Dotenv\Dotenv;
+use Dotenv\Exception\InvalidPathException;
+use DrupalFinder\DrupalFinder;
+
+// Locate .env file location.
+$dir = getcwd();
+$drupalFinder = new DrupalFinder();
+if ($drupalFinder->locateRoot($dir)) {
+  // If Drupal is available, use a .env in the parent directory.
+  $dir = realpath($drupalFinder->getDrupalRoot() . '/..');
+}
+
+$dir = dirname($dir);
+/**
+ * Load any .env file. See /.env.example.
+ */
+$dotenv = new Dotenv($dir);
+try {
+  $dotenv->load();
+}
+catch (InvalidPathException $e) {
+  // Do nothing. Production environments rarely use .env files.
+}

--- a/load.environment.php
+++ b/load.environment.php
@@ -17,7 +17,9 @@ if ($drupalFinder->locateRoot($dir)) {
   $dir = realpath($drupalFinder->getDrupalRoot() . '/..');
 }
 
+// Step up one directory from loaded dir, which should be drupal root.
 $dir = dirname($dir);
+
 /**
  * Load any .env file. See /.env.example.
  */


### PR DESCRIPTION
I removed the `.env` load logic since it wasn't working. This was the result of bad Drupal-Finder detection logic and that composer doesn't get loaded with Drush. Once fixing the logic in `load.environment.php`, this becomes an easy way to load config for use with Drush.